### PR TITLE
troca de link

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 				-->
 			</div>
 			<ul class="actions">
-				<li><a href="https://forms.gle/6w2xTe2tXeQ9CwHy7" target="_blank"
+				<li><a href="https://forms.gle/As7Ncz8Q7YgvNEVZ6" target="_blank"
 						class="button special big">Inscreva-se aqui</a></li>
 			</ul>
 		</div>


### PR DESCRIPTION
O link de "Inscreva-se aqui" para os espectadores redirecionava para o forms de inscrição dos instrutores. Corrigi para o link de inscrição para assistir as aulas.